### PR TITLE
Use readlink to provide absolute path to Godot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PLUGIN_NAME ?= $(shell grep 'plugin\.name' plugin.json | awk '{print $$2}' | gre
 
 GODOT ?= /usr/bin/godot
 OPENGAMEPAD_UI_REPO ?= https://github.com/ShadowBlip/OpenGamepadUI.git
-OPENGAMEPAD_UI_BASE ?= ../OpenGamepadUI
+OPENGAMEPAD_UI_BASE ?= $(shell readlink -e ../OpenGamepadUI)
 EXPORT_PRESETS ?= $(OPENGAMEPAD_UI_BASE)/export_presets.cfg
 PLUGINS_DIR := $(OPENGAMEPAD_UI_BASE)/plugins
 BUILD_DIR := $(OPENGAMEPAD_UI_BASE)/build


### PR DESCRIPTION
with the latest version of Godot, I can't run make install because it doesn't consider ../OpenGamepadUI a valid path.

```
/usr/bin/godot --headless \
        --path ../OpenGamepadUI \
        --export-pack "Lutris" \
        plugins/lutris/dist/lutris.zip
Invalid project path specified: "../OpenGamepadUI", aborting.
make: *** [Makefile:41: build] Error 1
```

Reading the absolute path fixes this 